### PR TITLE
Initial implementation of dynamic data sources

### DIFF
--- a/groups/rds/data.tf
+++ b/groups/rds/data.tf
@@ -59,3 +59,7 @@ data "vault_generic_secret" "fes_rds" {
 data "vault_generic_secret" "internal_cidrs" {
   path = "aws-accounts/network/internal_cidr_ranges"
 }
+
+data "vault_generic_secret" "chs_cidrs" {
+  path = "aws-accounts/network/${var.aws_account}/chs/application-subnets"
+}

--- a/groups/rds/data.tf
+++ b/groups/rds/data.tf
@@ -19,40 +19,19 @@ data "aws_security_group" "rds_shared" {
   }
 }
 
-data "aws_security_group" "ewf_fe_asg" {
+data "aws_security_group" "rds_ingress_abbyy" {
+  count = length(var.rds_ingress_groups["abbyy"])
   filter {
     name   = "group-name"
-    values = ["sgr-ewf-fe-asg*"]
+    values = [var.rds_ingress_groups["abbyy"][count.index]]
   }
 }
 
-data "aws_security_group" "ewf_fe_tux" {
-  filter {
-    name   = "tag:Name"
-    values = ["ewf-frontend-tuxedo-${var.environment}"]
-  }
-}
-
-data "aws_security_group" "ewf_bep_asg" {
+data "aws_security_group" "rds_ingress_fes" {
+  count = length(var.rds_ingress_groups["fes"])
   filter {
     name   = "group-name"
-    values = ["sgr-ewf-bep-asg*"]
-  }
-}
-
-data "aws_security_group" "fes_app_asg" {
-  count = var.account != "hlive" ? 1 : 0
-  filter {
-    name   = "group-name"
-    values = ["sgr-fes-app*"]
-  }
-}
-
-data "aws_security_group" "abbyy_app" {
-  count = var.account != "hdev" ? 1 : 0
-  filter {
-    name   = "group-name"
-    values = ["sgr-windows-workloads-abbyy*"]
+    values = [var.rds_ingress_groups["fes"][count.index]]
   }
 }
 

--- a/groups/rds/locals.tf
+++ b/groups/rds/locals.tf
@@ -10,59 +10,24 @@ locals {
   }
 
   rds_ingress_from_services = {
-    "abbyy" = concat(
-      var.account != "hlive" ? [
-        {
-          from_port                = 1521
-          to_port                  = 1521
-          protocol                 = "tcp"
-          description              = "Frontend Scanning App"
-          source_security_group_id = data.aws_security_group.fes_app_asg[0].id
-        }
-      ] : [],
-      var.account != "hdev" ? [
-        {
-          from_port                = 1521
-          to_port                  = 1521
-          protocol                 = "tcp"
-          description              = "ABBYY App"
-          source_security_group_id = data.aws_security_group.abbyy_app[0].id
-        }
-      ] : [],
-    )
-    "fes"   = concat([
-      {
+    "abbyy" = flatten([
+      for sg_data in data.aws_security_group.rds_ingress_abbyy : {
         from_port                = 1521
         to_port                  = 1521
         protocol                 = "tcp"
-        description              = "Frontend EWF"
-        source_security_group_id = data.aws_security_group.ewf_fe_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Backend EWF"
-        source_security_group_id = data.aws_security_group.ewf_bep_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Frontend Tuxedo EWF"
-        source_security_group_id = data.aws_security_group.ewf_fe_tux.id
+        description              = "Access from ${sg_data.tags.Name}"
+        source_security_group_id = sg_data.id
       }
-    ],
-      var.account != "hlive" ? [
-        {
-          from_port                = 1521
-          to_port                  = 1521
-          protocol                 = "tcp"
-          description              = "Frontend Scanning App"
-          source_security_group_id = data.aws_security_group.fes_app_asg[0].id
-        }
-      ] : [],
-    )
+    ])
+   "fes" = flatten([
+      for sg_data in data.aws_security_group.rds_ingress_fes : {
+        from_port                = 1521
+        to_port                  = 1521
+        protocol                 = "tcp"
+        description              = "Access from ${sg_data.tags.Name}"
+        source_security_group_id = sg_data.id
+      }
+    ])
   }
 
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])

--- a/groups/rds/locals.tf
+++ b/groups/rds/locals.tf
@@ -4,6 +4,11 @@
 locals {
   admin_cidrs    = values(data.vault_generic_secret.internal_cidrs.data)
 
+  app_cidrs = {
+    "abbyy" = []
+    "fes" = values(data.vault_generic_secret.chs_cidrs.data)
+  }
+
   rds_data = {
     abbyy = data.vault_generic_secret.abbyy_rds.data
     fes   = data.vault_generic_secret.fes_rds.data

--- a/groups/rds/profiles/heritage-development-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-development-eu-west-2/vars
@@ -162,9 +162,6 @@ rds_ingress_groups = {
     "sgr-fes-app*"
   ]
   fes = [
-    "sgr-ewf-fe-asg*",
-    "sgr-ewf-bep-asg*",
-    "ewf-frontend-tuxedo*",
     "sgr-fes-app*"
   ]
 }

--- a/groups/rds/profiles/heritage-development-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-development-eu-west-2/vars
@@ -155,3 +155,16 @@ parameter_group_settings = [
       value = "AUTO"
     },
 ]
+
+# Ingress security group patterns
+rds_ingress_groups = {
+  abbyy = [
+    "sgr-fes-app*"
+  ]
+  fes = [
+    "sgr-ewf-fe-asg*",
+    "sgr-ewf-bep-asg*",
+    "ewf-frontend-tuxedo*",
+    "sgr-fes-app*"
+  ]
+}

--- a/groups/rds/profiles/heritage-live-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-live-eu-west-2/vars
@@ -122,4 +122,12 @@ parameter_group_settings = [
     },
 ]
 
-
+# Ingress security group patterns
+rds_ingress_groups = {
+  abbyy = [
+    "sgr-windows-workloads-abbyy*",
+    "sgr-windows-workloads-smart_vault_1*",
+    "sgr-windows-workloads-smart_vault_2*"
+  ]
+  fes = []
+}

--- a/groups/rds/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-staging-eu-west-2/vars
@@ -156,4 +156,16 @@ parameter_group_settings = [
     },
 ]
 
-
+# Ingress security group patterns
+rds_ingress_groups = {
+  abbyy = [
+    "sgr-fes-app*",
+    "sgr-windows-workloads-abbyy*"
+  ]
+  fes = [
+    "sgr-ewf-fe-asg*",
+    "sgr-ewf-bep-asg*",
+    "ewf-frontend-tuxedo*",
+    "sgr-fes-app*"
+  ]
+}

--- a/groups/rds/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-staging-eu-west-2/vars
@@ -163,9 +163,6 @@ rds_ingress_groups = {
     "sgr-windows-workloads-abbyy*"
   ]
   fes = [
-    "sgr-ewf-fe-asg*",
-    "sgr-ewf-bep-asg*",
-    "ewf-frontend-tuxedo*",
     "sgr-fes-app*"
   ]
 }

--- a/groups/rds/rds.tf
+++ b/groups/rds/rds.tf
@@ -11,7 +11,7 @@ module "rds_security_group" {
   description = format("Security group for the ${each.key} RDS database")
   vpc_id      = data.aws_vpc.vpc.id
 
-  ingress_cidr_blocks = concat(local.admin_cidrs, each.value.rds_onpremise_access)
+  ingress_cidr_blocks = concat(local.admin_cidrs, each.value.rds_onpremise_access, local.app_cidrs[each.key])
   ingress_rules       = ["oracle-db-tcp"]
   ingress_with_cidr_blocks = [
     {

--- a/groups/rds/variables.tf
+++ b/groups/rds/variables.tf
@@ -46,7 +46,8 @@ variable "rds_databases" {
 }
 
 variable "rds_ingress_groups" {
-  type = map
+  type        = map(list(string))
+  description = "A map whose keys represent RDS instances and whose values are lists of strings representing security group filter patterns"
 }
 
 variable "parameter_group_settings" {

--- a/groups/rds/variables.tf
+++ b/groups/rds/variables.tf
@@ -45,6 +45,10 @@ variable "rds_databases" {
   type = map
 }
 
+variable "rds_ingress_groups" {
+  type = map
+}
+
 variable "parameter_group_settings" {
   type        = list(any)
   description = "A list of parameters that will be set in the RDS instance parameter group"


### PR DESCRIPTION
Added a dynamic data source, based on a map, to lookup data sources for ingress security groups.
This resolves an issue where certain SGs only exist in specific accounts, requiring lots of messy conditional statements to accommodate.

Added new `aws_security_group` data source for both the `abbyy` and `fes` instances - replaces individually defined per-SG data sources
Updated local var that is used to build the data required by the rds module
Added new profile vars to define the ingress SG name patterns required for each environment
