### PR TITLE
Rebuild FESDEV to Oracle 19

### DIFF
--- a/groups/rds/profiles/heritage-development-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-development-eu-west-2/vars
@@ -49,12 +49,12 @@ rds_databases = {
   },
   fes = {
     instance_class             = "db.t3.medium"
-    allocated_storage          = 30
+    allocated_storage          = 25
     backup_retention_period    = 2
     multi_az                   = false
     engine                     = "oracle-se2"
-    major_engine_version       = "12.1"
-    engine_version             = "12.1.0.2.v25"
+    major_engine_version       = "19"
+    engine_version             = "19"
     auto_minor_version_upgrade = true
     license_model              = "license-included"
     rds_maintenance_window     = "Thu:00:00-Thu:03:00"
@@ -162,12 +162,8 @@ parameter_group_settings = {
       value = "6"
     },
     {
-      name  = "sec_case_sensitive_logon"
-      value = "TRUE"
-    },
-    {
       name         = "compatible"
-      value        = "12.1.0.2.0"
+      value        = "19.0.0"
       apply_method = "pending-reboot"
     },
     {
@@ -212,6 +208,14 @@ parameter_group_settings = {
       name         = "sessions"
       value        = "6720"
       apply_method = "pending-reboot"
+    },
+    {
+      name  = "sqlnetora.sqlnet.allowed_logon_version_client"
+      value = "10"
+    },
+    {
+      name  = "sqlnetora.sqlnet.allowed_logon_version_server"
+      value = "10"
     },
     {
       name         = "timed_statistics"

--- a/groups/rds/profiles/heritage-development-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-development-eu-west-2/vars
@@ -84,7 +84,8 @@ rds_databases = {
 }
 
 # Parameter group settings
-parameter_group_settings = [
+parameter_group_settings = {
+  abbyy = [
     {
       name  = "aq_tm_processes"
       value = "6"
@@ -154,7 +155,79 @@ parameter_group_settings = [
       name  = "workarea_size_policy"
       value = "AUTO"
     },
-]
+  ],
+  fes = [
+    {
+      name  = "aq_tm_processes"
+      value = "6"
+    },
+    {
+      name  = "sec_case_sensitive_logon"
+      value = "TRUE"
+    },
+    {
+      name         = "compatible"
+      value        = "12.1.0.2.0"
+      apply_method = "pending-reboot"
+    },
+    {
+      name  = "db_file_multiblock_read_count"
+      value = "64"
+    },
+    {
+      name  = "job_queue_processes"
+      value = "1000"
+    },
+    {
+      name  = "nls_length_semantics"
+      value = "CHAR"
+    },
+    {
+      name  = "open_cursors"
+      value = "3000"
+    },
+    {
+      name  = "parallel_max_servers"
+      value = "20"
+    },
+    {
+      name  = "parallel_min_servers"
+      value = "10"
+    },
+    {
+      name         = "pga_aggregate_limit"
+      value        = "2147483648"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "processes"
+      value        = "4400"
+      apply_method = "pending-reboot"
+    },
+    {
+      name  = "remote_dependencies_mode"
+      value = "SIGNATURE"
+    },
+    {
+      name         = "sessions"
+      value        = "6720"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "timed_statistics"
+      value        = "TRUE"
+      apply_method = "pending-reboot"
+    },
+    {
+      name  = "undo_retention"
+      value = "900"
+    },
+    {
+      name  = "workarea_size_policy"
+      value = "AUTO"
+    },
+  ]
+}
 
 # Ingress security group patterns
 rds_ingress_groups = {

--- a/groups/rds/profiles/heritage-live-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-live-eu-west-2/vars
@@ -50,7 +50,8 @@ rds_databases = {
 }
 
 # Parameter group settings
-parameter_group_settings = [
+parameter_group_settings = {
+  abbyy = [
     {
       name  = "aq_tm_processes"
       value = "6"
@@ -120,7 +121,8 @@ parameter_group_settings = [
       name  = "workarea_size_policy"
       value = "AUTO"
     },
-]
+  ]
+}
 
 # Ingress security group patterns
 rds_ingress_groups = {

--- a/groups/rds/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-staging-eu-west-2/vars
@@ -84,7 +84,8 @@ rds_databases = {
 }
 
 # Parameter group settings
-parameter_group_settings = [
+parameter_group_settings = {
+  abbyy = [
     {
       name  = "aq_tm_processes"
       value = "6"
@@ -154,7 +155,79 @@ parameter_group_settings = [
       name  = "workarea_size_policy"
       value = "AUTO"
     },
-]
+  ],
+  fes = [
+    {
+      name  = "aq_tm_processes"
+      value = "6"
+    },
+    {
+      name  = "sec_case_sensitive_logon"
+      value = "TRUE"
+    },
+    {
+      name         = "compatible"
+      value        = "12.1.0.2.0"
+      apply_method = "pending-reboot"
+    },
+    {
+      name  = "db_file_multiblock_read_count"
+      value = "64"
+    },
+    {
+      name  = "job_queue_processes"
+      value = "1000"
+    },
+    {
+      name  = "nls_length_semantics"
+      value = "CHAR"
+    },
+    {
+      name  = "open_cursors"
+      value = "3000"
+    },
+    {
+      name  = "parallel_max_servers"
+      value = "20"
+    },
+    {
+      name  = "parallel_min_servers"
+      value = "10"
+    },
+    {
+      name         = "pga_aggregate_limit"
+      value        = "2147483648"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "processes"
+      value        = "4400"
+      apply_method = "pending-reboot"
+    },
+    {
+      name  = "remote_dependencies_mode"
+      value = "SIGNATURE"
+    },
+    {
+      name         = "sessions"
+      value        = "6720"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "timed_statistics"
+      value        = "TRUE"
+      apply_method = "pending-reboot"
+    },
+    {
+      name  = "undo_retention"
+      value = "900"
+    },
+    {
+      name  = "workarea_size_policy"
+      value = "AUTO"
+    },
+  ]
+}
 
 # Ingress security group patterns
 rds_ingress_groups = {

--- a/groups/rds/rds.tf
+++ b/groups/rds/rds.tf
@@ -88,7 +88,7 @@ module "rds" {
   # DB Parameter group
   family = join("-", [each.value.engine, each.value.major_engine_version])
 
-  parameters = var.parameter_group_settings
+  parameters = var.parameter_group_settings[each.key]
 
   options = concat([
     {

--- a/groups/rds/variables.tf
+++ b/groups/rds/variables.tf
@@ -51,6 +51,6 @@ variable "rds_ingress_groups" {
 }
 
 variable "parameter_group_settings" {
-  type        = list(any)
-  description = "A list of parameters that will be set in the RDS instance parameter group"
+  type        = map(list(any))
+  description = "A map whose keys represent RDS instances and whose values are a list of parameters that will be set in the RDS instance parameter group"
 }


### PR DESCRIPTION
Updated `parameter_group_settings` var to become an indexed map, allowing different parameter groups to be specified for each RDS instance
Updated `rds` module to use indexed `parameter_group_settings`
Updated environment variables to use new map
Updated dev vars to specify Oracle 19 settings for FES RDS

Resolves: CM-1178