### PR TITLE
Allow doc-sim access to ABBYY

### DIFF
--- a/groups/rds/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-staging-eu-west-2/vars
@@ -233,7 +233,8 @@ parameter_group_settings = {
 rds_ingress_groups = {
   abbyy = [
     "sgr-fes-app*",
-    "sgr-windows-workloads-abbyy*"
+    "sgr-windows-workloads-abbyy*",
+    "sgr-windows-workloads-doc-sim*"
   ]
   fes = [
     "sgr-fes-app*"


### PR DESCRIPTION
Added new security group pattern to permit access from `doc-sim` app server in staging to ABBYY RDS