### PR TITLE
Start up staging at 05:30 BST instead of 07:00 BST

### DIFF
--- a/groups/application/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/application/profiles/heritage-staging-eu-west-2/vars
@@ -17,7 +17,7 @@ fes_app_min_size = 1
 fes_app_max_size = 1
 fes_app_desired_capacity = 1
 fes_app_scaling_schedule_stop = "00 20 * * 1-5"
-fes_app_scaling_schedule_start = "00 06 * * 1-5"
+fes_app_scaling_schedule_start = "30 04 * * 1-5"
 
 
 fes_app_cw_logs = {


### PR DESCRIPTION
This is to allow testing to start earlier.  The schedule is in UTC/GMT, so the service was starting up a bit too late for testers who start at 6am.