### PR TITLE
Switch to m4.xlarge so that FES app can run

### DIFF
--- a/groups/application/profiles/heritage-development-eu-west-2/vars
+++ b/groups/application/profiles/heritage-development-eu-west-2/vars
@@ -12,7 +12,7 @@ application = "fes"
 environment = "development"
 
 # Frontend ASG settings
-fes_app_instance_size = "t3.medium"
+fes_app_instance_size = "m4.xlarge"
 fes_app_min_size = 1
 fes_app_max_size = 1
 fes_app_desired_capacity = 1


### PR DESCRIPTION
The dev instance has been restarting as there is not enough memory to start the app. This brings the instance type in line with staging.  
We can reduce the size of the instance again later, but will need to make the heap configuration part of deployment so that it is environment specific - currently it is set in the AMI to 8GB.