### PR TITLE
Add RDS CloudWatch Alarms

### DIFF
--- a/groups/rds/profiles/heritage-development-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-development-eu-west-2/vars
@@ -259,3 +259,16 @@ rds_start_stop_schedule = {
     rds_stop_schedule = "cron(0 21 * * ? *)"
   }
 }
+
+rds_cloudwatch_alarms = {
+  abbyy = {
+    alarm_actions_enabled = false
+    alarm_topic_name = ""
+    alarm_topic_name_ooh = ""
+  },
+  fes = {
+    alarm_actions_enabled = false
+    alarm_topic_name = ""
+    alarm_topic_name_ooh = ""
+  }
+}

--- a/groups/rds/profiles/heritage-live-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-live-eu-west-2/vars
@@ -269,3 +269,16 @@ rds_start_stop_schedule = {
     rds_stop_schedule = ""
   }
 }
+
+rds_cloudwatch_alarms = {
+  abbyy = {
+    alarm_actions_enabled = false
+    alarm_topic_name = "Email_Alerts"
+    alarm_topic_name_ooh = "Phonecall_Alerts"
+  },
+  fes = {
+    alarm_actions_enabled = false
+    alarm_topic_name = "Email_Alerts"
+    alarm_topic_name_ooh = "Phonecall_Alerts"
+  }
+}

--- a/groups/rds/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-staging-eu-west-2/vars
@@ -263,3 +263,16 @@ rds_start_stop_schedule = {
     rds_stop_schedule = "cron(0 21 * * ? *)"
   }
 }
+
+rds_cloudwatch_alarms = {
+  abbyy = {
+    alarm_actions_enabled = false
+    alarm_topic_name = ""
+    alarm_topic_name_ooh = ""
+  },
+  fes = {
+    alarm_actions_enabled = false
+    alarm_topic_name = ""
+    alarm_topic_name_ooh = ""
+  }
+}

--- a/groups/rds/rds.tf
+++ b/groups/rds/rds.tf
@@ -136,3 +136,15 @@ module "rds_start_stop_schedule" {
   rds_start_schedule  = lookup(each.value, "rds_start_schedule")
   rds_stop_schedule   = lookup(each.value, "rds_stop_schedule")
 }
+
+module "rds_cloudwatch_alarms" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/rds_cloudwatch_alarms?ref=tags/1.0.167"
+
+  for_each = var.rds_cloudwatch_alarms
+
+  rds_instance_id        = module.rds[each.key].this_db_instance_id
+  rds_instance_shortname = upper(each.key)
+  alarm_actions_enabled  = lookup(each.value, "alarm_actions_enabled")
+  alarm_topic_name       = lookup(each.value, "alarm_topic_name")
+  alarm_topic_name_ooh   = lookup(each.value, "alarm_topic_name_ooh")
+}

--- a/groups/rds/variables.tf
+++ b/groups/rds/variables.tf
@@ -59,3 +59,8 @@ variable "rds_start_stop_schedule" {
   type        = map(map(any))
   description = "A map whose keys represent RDS instances and whose values define configuration for RDS start/stop schedules"
 }
+
+variable "rds_cloudwatch_alarms" {
+  type        = map(map(any))
+  description = "A map whose keys represent RDS instances and whose values define RDS CloudWatch Alarms configuration"
+}


### PR DESCRIPTION
Added module and supporting config to deploy standard RDS CloudWatch alarms
alarm_actions currently disabled to prevent notification spam while alarms settle after creation