### PR TITLE
Per-profile RDS options, disable JVM in staging

### DIFF
--- a/groups/rds/profiles/heritage-development-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-development-eu-west-2/vars
@@ -18,7 +18,7 @@ rds_databases = {
     engine                     = "oracle-se2"
     major_engine_version       = "19"
     engine_version             = "19"
-    auto_minor_version_upgrade = true
+    auto_minor_version_upgrade = false
     license_model              = "license-included"
     rds_maintenance_window     = "Thu:00:00-Thu:03:00"
     rds_backup_window          = "03:01-06:00"
@@ -36,6 +36,16 @@ rds_databases = {
       "192.168.90.0/24"
     ]
     per_instance_options = [
+      {
+        option_name = "SQLT"
+        version     = "2018-07-25.v1"
+        option_settings = [
+          {
+            name  = "LICENSE_PACK"
+            value = "N"
+          },
+        ]
+      },
       {
         option_name = "Timezone"
         option_settings = [
@@ -70,6 +80,19 @@ rds_databases = {
       "192.168.90.0/24"
     ]
     per_instance_options = [
+      {
+        option_name = "JVM"
+      },
+      {
+        option_name = "SQLT"
+        version     = "2018-07-25.v1"
+        option_settings = [
+          {
+            name  = "LICENSE_PACK"
+            value = "N"
+          },
+        ]
+      },
       {
         option_name = "Timezone"
         option_settings = [

--- a/groups/rds/profiles/heritage-live-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-live-eu-west-2/vars
@@ -37,6 +37,19 @@ rds_databases = {
     ]
     per_instance_options = [
       {
+        option_name = "JVM"
+      },
+      {
+        option_name = "SQLT"
+        version     = "2018-07-25.v1"
+        option_settings = [
+          {
+            name  = "LICENSE_PACK"
+            value = "N"
+          },
+        ]
+      },
+      {
         option_name = "Timezone"
         option_settings = [
           {
@@ -70,6 +83,19 @@ rds_databases = {
       "192.168.90.0/24"
     ]
     per_instance_options = [
+      {
+        option_name = "JVM"
+      },
+      {
+        option_name = "SQLT"
+        version     = "2018-07-25.v1"
+        option_settings = [
+          {
+            name  = "LICENSE_PACK"
+            value = "N"
+          },
+        ]
+      },
       {
         option_name = "Timezone"
         option_settings = [

--- a/groups/rds/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-staging-eu-west-2/vars
@@ -18,7 +18,7 @@ rds_databases = {
     engine                     = "oracle-se2"
     major_engine_version       = "19"
     engine_version             = "19"
-    auto_minor_version_upgrade = true
+    auto_minor_version_upgrade = false
     license_model              = "license-included"
     rds_maintenance_window     = "Wed:00:00-Wed:03:00"
     rds_backup_window          = "03:01-06:00"
@@ -36,6 +36,16 @@ rds_databases = {
       "192.168.90.0/24"
     ]
     per_instance_options = [
+      {
+        option_name = "SQLT"
+        version     = "2018-07-25.v1"
+        option_settings = [
+          {
+            name  = "LICENSE_PACK"
+            value = "N"
+          },
+        ]
+      },
       {
         option_name = "Timezone"
         option_settings = [
@@ -55,7 +65,7 @@ rds_databases = {
     engine                     = "oracle-se2"
     major_engine_version       = "19"
     engine_version             = "19"
-    auto_minor_version_upgrade = true
+    auto_minor_version_upgrade = false
     license_model              = "license-included"
     rds_maintenance_window     = "Wed:00:00-Wed:03:00"
     rds_backup_window          = "03:01-06:00"
@@ -70,6 +80,16 @@ rds_databases = {
       "192.168.90.0/24"
     ]
     per_instance_options = [
+      {
+        option_name = "SQLT"
+        version     = "2018-07-25.v1"
+        option_settings = [
+          {
+            name  = "LICENSE_PACK"
+            value = "N"
+          },
+        ]
+      },
       {
         option_name = "Timezone"
         option_settings = [

--- a/groups/rds/rds.tf
+++ b/groups/rds/rds.tf
@@ -96,19 +96,6 @@ module "rds" {
       port                           = "5500"
       vpc_security_group_memberships = [module.rds_security_group[each.key].this_security_group_id]
     },
-    {
-      option_name = "JVM"
-    },
-    {
-      option_name = "SQLT"
-      version     = "2018-07-25.v1"
-      option_settings = [
-        {
-          name  = "LICENSE_PACK"
-          value = "N"
-        },
-      ]
-    },
   ], each.value.per_instance_options)
 
   timeouts = {

--- a/groups/rds/variables.tf
+++ b/groups/rds/variables.tf
@@ -42,7 +42,7 @@ variable "environment" {
 # RDS Variables
 # ------------------------------------------------------------------------------
 variable "rds_databases" {
-  type = map
+  type = any
 }
 
 variable "rds_ingress_groups" {


### PR DESCRIPTION
Moved RDS options in to vars to allow for per-profile changes
Updated rds.tf to concatenate standard OEM option with profile options
Removed JVM option and disabeld minor version upgrades in Staging
Updated development ABBYY to match deployed config