### PR TITLE
ALB monitoring adjustments

### DIFF
--- a/groups/application/alb-internal.tf
+++ b/groups/application/alb-internal.tf
@@ -108,6 +108,7 @@ module "internal_alb_alarms" {
   maximum_4xx_threshold     = "5"
   maximum_5xx_threshold     = "5"
   tls_negotiation_threshold = "5"
+  unhealthy_hosts_threshold = "0"
 
   # If actions are used then all alarms will have these applied, do not add any actions which you only want to be used for specific alarms
   # The module has lifecycle hooks to ignore changes via the AWS Console so in this use case the alarm can be modified there.

--- a/groups/application/variables.tf
+++ b/groups/application/variables.tf
@@ -81,7 +81,7 @@ variable "fes_app_service_port" {
 
 variable "fes_app_health_check_path" {
   type        = string
-  default     = "/"
+  default     = "/FES/faces/login.xhtml"
   description = "Target group health check path"
 }
 


### PR DESCRIPTION
Adjust the "unhealthy hosts threshold" to >0 so that if the FES EC2 instance is down, an alarm is raised.  This was set to the default of >2 previously, so the alarm was never raised.
Also updated the health check path so that it actually checks the app is up and running, as this was previously still reporting as healthy if tomcat was running and the app had failed to deploy.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1519